### PR TITLE
fix(security): Resolve validate_port_names search_path vulnerability

### DIFF
--- a/supabase/migrations/20250822101500_fix_validate_port_names_security.sql
+++ b/supabase/migrations/20250822101500_fix_validate_port_names_security.sql
@@ -1,0 +1,35 @@
+-- Migration: Correction de sécurité pour validate_port_names
+-- Date: 2025-08-22
+-- Description: Fix "role mutable search_path" security warning
+
+-- Supprimer et recréer la fonction avec pattern de sécurité strict
+DROP FUNCTION IF EXISTS validate_port_names() CASCADE;
+
+-- Recréer avec pattern de sécurité explicite
+CREATE OR REPLACE FUNCTION validate_port_names()
+RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = public  -- Correction: search_path explicite et immutable
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Validation basique des ports (peut être étendue avec une table de référence)
+    IF NEW.port_of_loading IS NOT NULL AND LENGTH(TRIM(NEW.port_of_loading)) = 0 THEN
+        RAISE EXCEPTION 'Port de chargement ne peut pas être vide';
+    END IF;
+    
+    IF NEW.port_of_discharge IS NOT NULL AND LENGTH(TRIM(NEW.port_of_discharge)) = 0 THEN
+        RAISE EXCEPTION 'Port de déchargement ne peut pas être vide';
+    END IF;
+    
+    RETURN NEW;
+END;
+$$;
+
+-- Recréer le trigger
+CREATE TRIGGER trigger_validate_ports 
+    BEFORE INSERT OR UPDATE ON bills_of_lading
+    FOR EACH ROW 
+    EXECUTE FUNCTION validate_port_names();
+
+-- Commentaire pour traçabilité
+COMMENT ON FUNCTION validate_port_names() IS 'Validation des noms de ports - Sécurisé avec search_path immutable';

--- a/supabase/migrations/20250822101600_fix_validate_port_names_empty_search_path.sql
+++ b/supabase/migrations/20250822101600_fix_validate_port_names_empty_search_path.sql
@@ -1,0 +1,35 @@
+-- Migration: Correction finale pour validate_port_names avec search_path vide
+-- Date: 2025-08-22
+-- Description: Utiliser search_path = '' (chaîne vide) pour conformité Supabase stricte
+
+-- Supprimer et recréer avec search_path vide (plus strict)
+DROP FUNCTION IF EXISTS validate_port_names() CASCADE;
+
+-- Recréer avec search_path vide (conformité Supabase maximale)
+CREATE OR REPLACE FUNCTION validate_port_names()
+RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = ''  -- Correction: search_path vide (plus strict que public)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Validation basique des ports (peut être étendue avec une table de référence)
+    IF NEW.port_of_loading IS NOT NULL AND LENGTH(TRIM(NEW.port_of_loading)) = 0 THEN
+        RAISE EXCEPTION 'Port de chargement ne peut pas être vide';
+    END IF;
+    
+    IF NEW.port_of_discharge IS NOT NULL AND LENGTH(TRIM(NEW.port_of_discharge)) = 0 THEN
+        RAISE EXCEPTION 'Port de déchargement ne peut pas être vide';
+    END IF;
+    
+    RETURN NEW;
+END;
+$$;
+
+-- Recréer le trigger
+CREATE TRIGGER trigger_validate_ports 
+    BEFORE INSERT OR UPDATE ON public.bills_of_lading
+    FOR EACH ROW 
+    EXECUTE FUNCTION validate_port_names();
+
+-- Commentaire pour traçabilité
+COMMENT ON FUNCTION validate_port_names() IS 'Validation des noms de ports - Sécurisé avec search_path vide (conformité Supabase stricte)';


### PR DESCRIPTION
## Summary
- Résout l'avertissement Supabase Security Advisor : *"Function `public.validate_port_names` has a role mutable search_path"*
- Applique `SET search_path = ''` (chaîne vide) pour sécurité maximale sur les fonctions PostgreSQL
- Recréé la fonction `validate_port_names` avec pattern de sécurité strict `SECURITY DEFINER`

## Security Impact
🛡️ **Vulnérabilité corrigée** : Empêche la manipulation potentielle du `search_path` par des attaquants
🔒 **Principe de moindre privilège** : Applique les standards de sécurité PostgreSQL les plus stricts  
✅ **Conformité Supabase** : Résout tous les avertissements du Security Advisor

## Technical Details
- **Avant** : `SET search_path = public` (mutable, détecté comme vulnérable)  
- **Après** : `SET search_path = ''` (immutable, sécurité maximale)
- **Pattern** : `SECURITY DEFINER` avec search_path vide (standard Supabase recommandé)

## Test plan
- [x] Vérifier que l'avertissement Supabase Security a disparu
- [x] Confirmer que la fonction `validate_port_names` fonctionne correctement
- [x] Valider que les triggers sur `bills_of_lading` sont opérationnels
- [x] Tester les validations de ports (loading/discharge) en base

## Files Changed
- `supabase/migrations/20250822101500_fix_validate_port_names_security.sql` - Première tentative avec `search_path = public`
- `supabase/migrations/20250822101600_fix_validate_port_names_empty_search_path.sql` - Solution finale avec `search_path = ''`

🤖 Generated with [Claude Code](https://claude.ai/code)